### PR TITLE
skip a test if the test DB is misbehaving

### DIFF
--- a/oauth/suite_test.go
+++ b/oauth/suite_test.go
@@ -41,7 +41,7 @@ type OauthTestSuite struct {
 	suite.Suite
 	cnf     *config.Config
 	db      *gorm.DB
-	db2      *gorm.DB
+	db2     *gorm.DB
 	service *oauth.Service
 	clients []*models.OauthClient
 	users   []*models.OauthUser
@@ -63,7 +63,7 @@ func (suite *OauthTestSuite) SetupSuite() {
 		testFixtures,
 	)
 	if err != nil {
-		log.ERROR.Fatal(err)
+		t.Skip(err)
 	}
 	suite.db = db
 	suite.db2 = nil // TODO setup test mysql db client


### PR DESCRIPTION
Hi there,

I adjusted the oauth test suite to skip a test if the test database is misbehaving. The oauth test suite should ensure that the oauth code is tested, not that the test rig is up and running. (This should be ensured elsewhere if need be.)
A failing oauth test should indicate an error in the oauth code, nothing else.

Cheers,
tpltnt