### PR TITLE
fix: remove ternary from release form

### DIFF
--- a/frontend/src/components/forms/basic-info.js
+++ b/frontend/src/components/forms/basic-info.js
@@ -826,16 +826,14 @@ class ProfileForm extends Component {
 
             ${submitButton()}
           </form>
-          ${this.local.role === 'artist'
-            ? <div class="relative flex items-center">
-                <h4>
-                  <br/>
-                  <a href="https://forms.gle/VZok9gA1FDzznewW9">
-                    New Release Submission Form
-                  </a>
-                </h4>
-              </div>
-            : ''}
+          <div class="relative flex items-center">
+            <h4>
+              <br/>
+              <a href="https://forms.gle/VZok9gA1FDzznewW9">
+                New Release Submission Form
+              </a>
+            </h4>
+          </div>
         </div>
       </div>
     `


### PR DESCRIPTION
Addresses this error:
```sh
[21:29:45] 'javascript' errored after 4.94 s
[21:29:45] SyntaxError: /build/id/frontend/src/components/forms/basic-info.js: Support for the experimental syntax 'jsx' isn't currently enabled (830:15):

  828 |           </form>
  829 |           ${this.local.role === 'artist'
> 830 |             ? <div class="relative flex items-center">
      |               ^
  831 |                 <h4>
  832 |                   <br/>
  833 |                   <a href="https://forms.gle/VZok9gA1FDzznewW9">

Add @babel/preset-react (https://github.com/babel/babel/tree/main/packages/babel-preset-react) to the 'presets' section of your Babel config to enable transformation.
If you want to leave it as-is, add @babel/plugin-syntax-jsx (https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-jsx) to the 'plugins' section to enable parsing.
    at instantiate (/build/id/frontend/node_modules/@babel/parser/lib/index.js:72:32)
    at constructor (/build/id/frontend/node_modules/@babel/parser/lib/index.js:358:12)
    at Parser.raise (/build/id/frontend/node_modules/@babel/parser/lib/index.js:3341:19)
    at Parser.expectOnePlugin (/build/id/frontend/node_modules/@babel/parser/lib/index.js:3398:18)
    at Parser.parseExprAtom (/build/id/frontend/node_modules/@babel/parser/lib/index.js:13073:18)
    at Parser.parseExprSubscripts (/build/id/frontend/node_modules/@babel/parser/lib/index.js:12643:23)
    at Parser.parseUpdate (/build/id/frontend/node_modules/@babel/parser/lib/index.js:12622:21)
    at Parser.parseMaybeUnary (/build/id/frontend/node_modules/@babel/parser/lib/index.js:12593:23)
    at Parser.parseMaybeUnaryOrPrivate (/build/id/frontend/node_modules/@babel/parser/lib/index.js:12387:61)
    at Parser.parseExprOps (/build/id/frontend/node_modules/@babel/parser/lib/index.js:12394:23)
ERROR: Service 'id-server' failed to build: The command '/bin/sh -c cd /build/id/frontend && npm run build' returned a non-zero code: 1
```