### PR TITLE
fix: increase email token expiry time 30 mins

### DIFF
--- a/oauth/email_token.go
+++ b/oauth/email_token.go
@@ -92,7 +92,7 @@ func (s *Service) SendEmailTokenTx(
 
 // CreateEmailToken ...
 func (s *Service) CreateEmailToken(email string) (*model.EmailToken, error) {
-	expiresIn := 10 * time.Minute // 10 minutes
+	expiresIn := 30 * time.Minute // 30 minutes
 
 	emailToken := model.NewOauthEmailToken(&expiresIn)
 


### PR DESCRIPTION
Our Mailgun emails are taking 20+ mins to send because it's a free account. This will increase the allowable window to 30 minutes.