### PR TITLE
Avoid setting csrf header twice

### DIFF
--- a/web/profile.go
+++ b/web/profile.go
@@ -20,8 +20,6 @@ func (s *Service) profileForm(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set("X-CSRF-Token", csrf.Token(r))
-
 	if !isUserAccountComplete {
 		err = sessionService.SetFlashMessage(&session.Flash{
 			Type:    "Info",
@@ -35,6 +33,8 @@ func (s *Service) profileForm(w http.ResponseWriter, r *http.Request) {
 		redirectWithQueryString("/web/account", query, w, r)
 		return
 	}
+
+	w.Header().Set("X-CSRF-Token", csrf.Token(r))
 
 	// Render the template
 	flash, _ := sessionService.GetFlashMessage()


### PR DESCRIPTION
If the user account is not complete, the csrf token is being set a twice after redirection. I don't have a way to test this but it's safe enough to try.