### PR TITLE
Do not record user memberships and membership shares data in postgres db anymore

### DIFF
--- a/webhook/stripe_payment.go
+++ b/webhook/stripe_payment.go
@@ -150,6 +150,7 @@ func (s *Service) stripePayment(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
+		/* BROKEN!
 		if session.Metadata["shares"] != "" {
 			log.INFO.Printf("Number of shares: %s", session.Metadata["shares"])
 
@@ -182,6 +183,7 @@ func (s *Service) stripePayment(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		}
+		*/
 
 		if session.Metadata["credits"] != "" {
 			log.INFO.Printf("Number of credits: %s", session.Metadata["credits"])
@@ -255,10 +257,12 @@ func (s *Service) processMembership(customerEmail, subscriptionID, productID str
 	}
 
 	if templateName != "" {
+		/* BROKEN!
 		if err = s.AddMembership(user, productID, subscriptionID); err != nil {
 			log.ERROR.Print(err)
 			return err
 		}
+		*/
 
 		if err = s.GrantMemberStatus(customerEmail, true); err != nil {
 			log.ERROR.Print(err)

--- a/webhook/stripe_payment.go
+++ b/webhook/stripe_payment.go
@@ -238,7 +238,7 @@ func (s *Service) stripePayment(w http.ResponseWriter, r *http.Request) {
 
 // processMembership
 func (s *Service) processMembership(customerEmail, subscriptionID, productID string) error {
-	user, err := s.oauthService.FindUserByUsername(customerEmail)
+	_, err := s.oauthService.FindUserByUsername(customerEmail)
 
 	if err != nil {
 		log.ERROR.Print(err)


### PR DESCRIPTION
We're not going to fix this so let's just stop recording user memberships data into our own db.